### PR TITLE
Add an inline icon next to highlighted nations (+minor typo fix)

### DIFF
--- a/coop_auction_highlighter.user.js
+++ b/coop_auction_highlighter.user.js
@@ -72,6 +72,19 @@ function GM_addStyle(style) {
 					);
 				}
 			});
+        document
+			.querySelectorAll("a.nlink:not(.hn67-class-xki-cardcoop-parsed)")
+			.forEach(function (el, i) {
+				const canonical_nname = el
+					.getAttribute("href")
+					.replace(/^nation=/, "");
+				if (guild_members_array.includes(canonical_nname)) {
+					const new_el = document.createElement("span");
+					new_el.classList.add("hn67-class-xki-cardcoop-inline");
+					el.parentNode.insertBefore(new_el, el);
+					el.classList.add("hn67-class-xki-cardcoop-parsed");
+				}
+			});
 	};
 
 	if (document.getElementById("auctiontablebox")) {
@@ -134,6 +147,12 @@ background-position: left;
 tr > td.hn67-class-xki-cardcoop:nth-child(5) {
 background-image: linear-gradient(270deg, rgba(255,255,255,0), rgb(255,255,255) 50px, rgba(255, 255, 255, 0) 100px), ` + image + `;
 background-position: right;
+}
+.hn67-class-xki-cardcoop-inline {
+background-repeat: no-repeat;
+background-image: ` + image + `;
+background-size: contain;
+padding-left: 1.5em;
 }
 `);
 	}

--- a/coop_auction_highlighter.user.js
+++ b/coop_auction_highlighter.user.js
@@ -1,6 +1,6 @@
 // ==UserScript==
 // @name         Co-op Auction Highlighter
-// @version      0.1
+// @version      0.2
 // @namespace    HN67
 // @description  Adds XKI's Card Co-op logo beside members nations during an auction
 // @author       HN67

--- a/coop_auction_highlighter.user.js
+++ b/coop_auction_highlighter.user.js
@@ -68,7 +68,7 @@ function GM_addStyle(style) {
 					);
 				} else {
 					el.parentNode.parentNode.classList.remove(
-						"hn67-class-xki-card_coop"
+						"hn67-class-xki-cardcoop"
 					);
 				}
 			});


### PR DESCRIPTION
Adds a mini-icon next to member nations, similarly to other highlighters. Very useful when running multiple org highlighters together (all the org icons appear).
Example (icons on the left):
![image](https://user-images.githubusercontent.com/16628163/112134543-26c60400-8bcd-11eb-9b10-3b55a99f903c.png)
